### PR TITLE
Fix failing tests

### DIFF
--- a/Tests/VCRURLConnectionTests.m
+++ b/Tests/VCRURLConnectionTests.m
@@ -160,7 +160,9 @@
 }
 
 - (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
-    self.data = data;
+    NSMutableData *currentData = [NSMutableData dataWithData:self.data];
+    [currentData appendData:data];
+    self.data = currentData;
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection {


### PR DESCRIPTION
Tests began to fail because the run against a live URL, which was no longer valid.
