### PR TITLE
Multiple requests to the same URI/method return results as recorded

### DIFF
--- a/Tests/VCRCassetteTests.m
+++ b/Tests/VCRCassetteTests.m
@@ -50,7 +50,7 @@
 
 - (void)testInit {
     VCRCassette *cassette = [VCRCassette cassette];
-    XCTAssertNotNil(cassette.responseDictionary, @"Must have response dictionary");
+    XCTAssertNotNil(cassette.responseArray, @"Must have response list");
 }
 
 - (void)testInitWithData {
@@ -120,6 +120,20 @@
     VCRCassette *cassette = [[VCRCassette alloc] initWithJSON:self.recordings];
     NSData *data = [cassette data];
     XCTAssertTrue(data != nil && [data length] > 0, @"Did not serialize to data");
+}
+
+- (void)testOrderedDuplicates {
+    id recordings = @[
+        @{ @"method": @"get", @"uri": @"http://time.com/utc", @"body": @"10:31" },
+        @{ @"method": @"get", @"uri": @"http://time.com/utc", @"body": @"10:30" }
+    ];  // JSON files seem to be ordered bottom to top
+    VCRCassette *cassette = [[VCRCassette alloc] initWithJSON:recordings];
+
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://time.com/utc"]];
+    VCRRecording *firstReturned = [cassette recordingForRequest:request];
+    STAssertEqualObjects(firstReturned.body, @"10:30", @"first response");
+    VCRRecording *secondReturned = [cassette recordingForRequest:request];
+    STAssertEqualObjects(secondReturned.body, @"10:31", @"second response");
 }
 
 @end

--- a/Tests/VCRCassetteTests.m
+++ b/Tests/VCRCassetteTests.m
@@ -124,16 +124,16 @@
 
 - (void)testOrderedDuplicates {
     id recordings = @[
-        @{ @"method": @"get", @"uri": @"http://time.com/utc", @"body": @"10:31" },
-        @{ @"method": @"get", @"uri": @"http://time.com/utc", @"body": @"10:30" }
-    ];  // JSON files seem to be ordered bottom to top
+        @{ @"method": @"get", @"uri": @"http://time.com/utc", @"body": @"10:30" },
+        @{ @"method": @"get", @"uri": @"http://time.com/utc", @"body": @"10:31" }
+    ];
     VCRCassette *cassette = [[VCRCassette alloc] initWithJSON:recordings];
 
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"http://time.com/utc"]];
     VCRRecording *firstReturned = [cassette recordingForRequest:request];
-    STAssertEqualObjects(firstReturned.body, @"10:30", @"first response");
+    XCTAssertEqualObjects(firstReturned.body, @"10:30", @"first response");
     VCRRecording *secondReturned = [cassette recordingForRequest:request];
-    STAssertEqualObjects(secondReturned.body, @"10:31", @"second response");
+    XCTAssertEqualObjects(secondReturned.body, @"10:31", @"second response");
 }
 
 @end

--- a/Tests/VCRIntegrationTests.m
+++ b/Tests/VCRIntegrationTests.m
@@ -1,0 +1,70 @@
+#import <XCTest/XCTest.h>
+#import "XCTestCase+SRTAdditions.h"
+#import "VCR.h"
+
+@interface VCRIntegrationTests : XCTestCase
+
+@property (nonatomic, assign) BOOL finishedLoading;
+@property (nonatomic, strong) NSHTTPURLResponse *lastResponse;
+@property (nonatomic, strong) NSMutableData *currentData;
+
+- (NSString *)bodyFromURL:(NSString *)urlString;
+
+@end
+
+
+@implementation VCRIntegrationTests
+
+- (void)tearDown
+{
+    [[NSFileManager defaultManager] removeItemAtPath:@"/tmp/cassette.json" error:nil];
+    [super tearDown];
+}
+
+- (void)testDuplicates {
+    // Record hitting a URL 3 times
+    [VCR startRecordingDuplicates];
+    NSString *one = [self bodyFromURL:@"http://www.timeapi.org/utc/now"];
+    [NSThread sleepForTimeInterval:1];
+    NSString *two = [self bodyFromURL:@"http://www.timeapi.org/utc/now"];
+    [NSThread sleepForTimeInterval:1];
+    NSString *three = [self bodyFromURL:@"http://www.timeapi.org/utc/now"];
+    [VCR save:@"/tmp/cassette.json"];
+    [VCR stop];
+
+    // Make sure replay happens in same order
+    NSURL *cassetteURL = [NSURL fileURLWithPath:@"/tmp/cassette.json"];
+    [VCR loadCassetteWithContentsOfURL:cassetteURL];
+    [VCR start];
+    XCTAssertEqualObjects(one, [self bodyFromURL:@"http://www.timeapi.org/utc/now"]);
+    XCTAssertEqualObjects(two, [self bodyFromURL:@"http://www.timeapi.org/utc/now"]);
+    XCTAssertEqualObjects(three, [self bodyFromURL:@"http://www.timeapi.org/utc/now"]);
+    [VCR stop];
+}
+
+- (NSString *)bodyFromURL:(NSString *)urlString {
+    self.finishedLoading = NO;
+    self.currentData = [[NSMutableData alloc] init];
+    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:urlString]
+                                             cachePolicy:NSURLRequestReloadIgnoringCacheData
+                                         timeoutInterval:(5 * 60)];
+    [NSURLConnection connectionWithRequest:request delegate:self];
+    [self runCurrentRunLoopUntilTestPasses:^BOOL{ return self.finishedLoading; } timeout:(5 * 60)];
+    return [[NSString alloc] initWithData:self.currentData encoding:NSUTF8StringEncoding];
+}
+
+#pragma mark - NSURLConnection delegate methods
+
+- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
+    self.finishedLoading = YES;
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
+    self.lastResponse = (NSHTTPURLResponse *)response;
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
+    [self.currentData appendData:data];
+}
+
+@end

--- a/VCRURLConnection.xcodeproj/project.pbxproj
+++ b/VCRURLConnection.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AABFBEB1187662760012703A /* VCRIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AABFBEB0187662760012703A /* VCRIntegrationTests.m */; };
+		AABFBEB2187662760012703A /* VCRIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AABFBEB0187662760012703A /* VCRIntegrationTests.m */; };
 		B317B687186E13B400A7C0AE /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B317B686186E13B400A7C0AE /* XCTest.framework */; };
 		B317B689186E13B400A7C0AE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B317B688186E13B400A7C0AE /* Foundation.framework */; };
 		B317B68A186E13B400A7C0AE /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3475B8B167EA37B0044511D /* UIKit.framework */; };
@@ -73,6 +75,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		AABFBEB0187662760012703A /* VCRIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = VCRIntegrationTests.m; path = Tests/VCRIntegrationTests.m; sourceTree = "<group>"; };
 		B317B685186E13B400A7C0AE /* Tests-iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests-iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B317B686186E13B400A7C0AE /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		B317B688186E13B400A7C0AE /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
@@ -309,6 +312,7 @@
 				B3B8287D167E9B2B00CCEC3C /* cassette-1.json */,
 				B3475B8D167EBF8F0044511D /* test.png */,
 				B3BB251B167F243E00C5E3C6 /* Vendor */,
+				AABFBEB0187662760012703A /* VCRIntegrationTests.m */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -469,6 +473,7 @@
 				B317B6A5186E180900A7C0AE /* VCRConnectionDelegate.m in Sources */,
 				B317B6A2186E180900A7C0AE /* VCR.m in Sources */,
 				B317B6A6186E180900A7C0AE /* VCROrderedMutableDictionary.m in Sources */,
+				AABFBEB1187662760012703A /* VCRIntegrationTests.m in Sources */,
 				B317B6A7186E180900A7C0AE /* VCRRecording.m in Sources */,
 				B317B69E186E13DD00A7C0AE /* VCRURLConnectionTests.m in Sources */,
 				B317B6A9186E180900A7C0AE /* VCRError.m in Sources */,
@@ -492,6 +497,7 @@
 				B317B6BF186E1A5100A7C0AE /* VCRCassetteManager.m in Sources */,
 				B317B6C7186E1A5E00A7C0AE /* VCRCassetteTests.m in Sources */,
 				B317B6C1186E1A5100A7C0AE /* VCROrderedMutableDictionary.m in Sources */,
+				AABFBEB2187662760012703A /* VCRIntegrationTests.m in Sources */,
 				B317B6C6186E1A5E00A7C0AE /* VCRCassetteManagerTests.m in Sources */,
 				B317B6C4186E1A5100A7C0AE /* VCRError.m in Sources */,
 				B317B6C9186E1A5E00A7C0AE /* VCRRequestKeyTests.m in Sources */,

--- a/VCRURLConnection/VCR.h
+++ b/VCRURLConnection/VCR.h
@@ -77,6 +77,11 @@
 + (void)start;
 
 /**
+ Begin recording everything
+ */
++ (void)startRecordingDuplicates;
+
+/**
  Stop recording or replaying HTTP interactions
  */
 + (void)stop;
@@ -87,5 +92,8 @@
  @param path the output path
  */
 + (void)save:(NSString *)path;
+
+
++ (BOOL)recordingDuplicates;
 
 @end

--- a/VCRURLConnection/VCRCassette.m
+++ b/VCRURLConnection/VCRCassette.m
@@ -78,7 +78,7 @@
     if (i + 1 > results.count) {
         i = results.count - 1;
     }
-    return [results objectAtIndex:(results.count - i - 1)]; // get the last one first
+    return [results objectAtIndex:i];
 }
 
 - (VCRRecording *)recordingForRequest:(NSURLRequest *)request {

--- a/VCRURLConnection/VCRCassette_Private.h
+++ b/VCRURLConnection/VCRCassette_Private.h
@@ -25,6 +25,7 @@
 
 @interface VCRCassette ()
 
-@property (nonatomic, strong) NSMutableDictionary *responseDictionary;
+@property (nonatomic, strong) NSMutableArray *responseArray;
+@property (nonatomic, strong) NSMutableDictionary *sequenceDictionary;
 
 @end

--- a/VCRURLConnection/VCRConnectionDelegate.m
+++ b/VCRURLConnection/VCRConnectionDelegate.m
@@ -77,6 +77,7 @@
 
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSHTTPURLResponse *)response {
     self.recording.headerFields = response.allHeaderFields;
+    self.recording.statusCode = response.statusCode;
     if ([_wrapped respondsToSelector:@selector(connection:didReceiveResponse:)]) {
         [_wrapped connection:connection didReceiveResponse:response];
     }


### PR DESCRIPTION
Hi Dustin,

First of all, thanks for creating VCRURLConnection!  We've loved using VCR on ruby projects and were excited to find someone maintaining a objective-c version.  We're using it for all of our acceptance tests on our new mobile app.

We noticed that multiple requests to the same URI/method would return the same result.  This pull request is a fix that we're using from our forked version.  We'd love to get your feedback on this approach and ultimately have this functionality contributed back into your version.

We're under the pump at the moment trying to get a release out, ideally we'd like to clean up and test the logic in recordingForRequestKey:key some more.  We thought we'd reach out to you about the general approach first.

Thanks again, we look forward to your response.