### PR TITLE
Add a whitelist of known text MIME types

### DIFF
--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -70,6 +70,9 @@
 
 - (BOOL)isText {
     NSString *type = [[self HTTPURLResponse] MIMEType] ?: @"text/plain";
+    if ([@[ @"application/x-www-form-urlencoded" ] containsObject:type]) {
+        return YES;
+    }
     CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)type, NULL);
     BOOL isText = UTTypeConformsTo(uti, kUTTypeText);
     if (uti) {


### PR DESCRIPTION
Some MIME types may not have a corresponding UTI and thus can't conform to `public.text`
