### PR TITLE
Allow regular expression URI matching from a JSON recording

### DIFF
--- a/Tests/VCRCassetteTests.m
+++ b/Tests/VCRCassetteTests.m
@@ -130,6 +130,24 @@
     XCTAssertNil([cassette recordingForRequest:request]);
 }
 
+- (void)testPreferExactMatchesOverRegularExpressionMatches {
+    NSString *path = @"http://foo?key=xyz";
+    NSURL *url = [NSURL URLWithString:path];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    
+    id json = @{ @"method": @"GET", @"uri": @"http://foo[?]*.*", @"body": @"Foo Bar" };
+    VCRRecording *regexRecording = [[VCRRecording alloc] initWithJSON:json];
+    
+    VCRCassette *cassette = self.cassette;
+    [cassette addRecording:regexRecording];
+
+    json = @{ @"method": @"GET", @"uri": path, @"body": @"Foo Baz" };
+    VCRRecording *pathRecording = [[VCRRecording alloc] initWithJSON:json];
+    [cassette addRecording:pathRecording];
+    
+    XCTAssertEqualObjects([cassette recordingForRequest:request], pathRecording, @"");
+}
+
 - (void)testKeyOrderingForJson {
     id json = @{ @"method": @"get", @"uri": @"http://foo", @"body": @"GET Foo Bar Baz" };
     VCRRecording *recording = [[VCRRecording alloc] initWithJSON:json];

--- a/Tests/VCRCassetteTests.m
+++ b/Tests/VCRCassetteTests.m
@@ -108,6 +108,28 @@
     XCTAssertEqualObjects([cassette recordingForRequest:request1], recording, @"");
 }
 
+- (void)testRecordingForRequestByMatchingRegularExpression {
+    NSURL *url = [NSURL URLWithString:@"http://foo?key=abc"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    id json = @{ @"method": @"GET", @"uri": @"http://foo[?]*.*", @"body": @"Foo Bar Baz" };
+    VCRRecording *recording = [[VCRRecording alloc] initWithJSON:json];
+    
+    VCRCassette *cassette = self.cassette;
+    [cassette addRecording:recording];
+    XCTAssertEqualObjects([cassette recordingForRequest:request], recording, @"");
+}
+
+- (void)testRegExRecordingForRequestGreedy {
+    NSURL *url = [NSURL URLWithString:@"http://bar?key=abc"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
+    id json = @{ @"method": @"GET", @"uri": @"http://foo[?]*.*", @"body": @"Foo Bar Baz" };
+    VCRRecording *recording = [[VCRRecording alloc] initWithJSON:json];
+    
+    VCRCassette *cassette = self.cassette;
+    [cassette addRecording:recording];
+    XCTAssertNil([cassette recordingForRequest:request]);
+}
+
 - (void)testKeyOrderingForJson {
     id json = @{ @"method": @"get", @"uri": @"http://foo", @"body": @"GET Foo Bar Baz" };
     VCRRecording *recording = [[VCRRecording alloc] initWithJSON:json];

--- a/VCRURLConnection/VCRCassette.m
+++ b/VCRURLConnection/VCRCassette.m
@@ -69,7 +69,23 @@
 }
 
 - (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)key {
-    return [self.responseDictionary objectForKey:key];
+    __block VCRRecording *recording = [self.responseDictionary objectForKey:key];
+
+    if (!recording) {
+        [self.responseDictionary enumerateKeysAndObjectsUsingBlock:^(VCRRequestKey *responseKey, id obj, BOOL *stop) {
+            if ([responseKey.method isEqualToString:key.method]) {
+                NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:responseKey.URI
+                                                                                       options:0
+                                                                                         error:NULL];
+                if (regex && [regex numberOfMatchesInString:key.URI options:0 range:NSMakeRange(0, key.URI.length)] > 0) {
+                    recording = obj;
+                    *stop = YES;
+                }
+            }
+        }];
+    }
+
+    return recording;
 }
 
 - (VCRRecording *)recordingForRequest:(NSURLRequest *)request {


### PR DESCRIPTION
As described in dstnbrkr/VCRURLConnection/issues/23, my server's API uses time-based hashes in the URI, which breaks the recoring-lookup by VCR.

Because the URI structure is always the same, with merely the hash changing, I wanted to propose allowing regular expression matches in the recorded JSON files to get VCR to work with expected changes in the URI.

I've added three test methods to cover the added behavior, without breaking the existing one.

Is this something you'd consider merging, @dstnbrkr?