### PR TITLE
Pass auth challenges through to NSURLProtocol client

### DIFF
--- a/VCRURLConnection/VCRRecordingURLProtocol.m
+++ b/VCRURLConnection/VCRRecordingURLProtocol.m
@@ -67,6 +67,14 @@ static NSString * const VCRIsRecordingRequestKey = @"VCR_recording";
 
 #pragma mark = NSURLConnectionDelegate
 
+- (BOOL)connection:(NSURLConnection *)connection canAuthenticateAgainstProtectionSpace:(NSURLProtectionSpace *)protectionSpace {
+    return YES;
+}
+
+- (void)connection:(NSURLConnection *)connection didReceiveAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge {
+    [self.client URLProtocol:self didReceiveAuthenticationChallenge:challenge];
+}
+
 - (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSHTTPURLResponse *)response {
     self.recording.headerFields = response.allHeaderFields;
     self.recording.statusCode = response.statusCode;


### PR DESCRIPTION
A self-signed certificate is presented to the NSURLConnection delegate as an authentication challenge. When recording a request, forward the challenge to the NSURLProtocol’s client so the application logic can decide to accept or reject it.

Without this change, the URL loading system (at least on iOS 9 and later) rejects self-signed certificates, displaying `errSSLNoRootCert` (-9813) and `errSSLClosedAbort` (-9806) on the console.