### PR TITLE
Fixes build error when using the dynamic framework on iOS

### DIFF
--- a/VCRURLConnection/VCRURLConnection.h
+++ b/VCRURLConnection/VCRURLConnection.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for VCRURLConnection.
 FOUNDATION_EXPORT double VCRURLConnectionVersionNumber;


### PR DESCRIPTION
When I try to import the project in my iOS application test target using CocoaPods and the `use_frameworks!` option, I'm getting build errors, because the `Cocoa/Cocoa.h` file can't be found.

You can easily see that error when trying to lint the `VCRURLConnection` pod using `pod lib lint VCRURLConnection.podspec --verbose`: 
`fatal error: 'Cocoa/Cocoa.h' file not found`

Importing `Foundation/Foundation.h` will work for both macOS and iOS, and linting the pod passes.