### PR TITLE
Support multiple requests for the same url

### DIFF
--- a/VCRURLConnection/VCRCassette.h
+++ b/VCRURLConnection/VCRCassette.h
@@ -37,8 +37,10 @@
 - (void)addRecording:(VCRRecording *)recording;
 
 - (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)request;
+- (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)request replaying:(BOOL)replaying;
 
 - (VCRRecording *)recordingForRequest:(NSURLRequest *)request;
+- (VCRRecording *)recordingForRequest:(NSURLRequest *)request replaying:(BOOL)replaying;
 
 - (NSArray *)allKeys;
 

--- a/VCRURLConnection/VCRCassette.m
+++ b/VCRURLConnection/VCRCassette.m
@@ -82,7 +82,7 @@
 
 - (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)key replaying:(BOOL)replaying {
     __block VCRRecording *recording;
-    __block NSMutableArray *recordings = [self.responseDictionary objectForKey:key];
+    NSMutableArray *recordings = [self.responseDictionary objectForKey:key];
 
     if (recordings != NULL && recordings.count > 0) {
         recording = [recordings objectAtIndex:0];

--- a/VCRURLConnection/VCRCassette.m
+++ b/VCRURLConnection/VCRCassette.m
@@ -67,14 +67,30 @@
 - (void)addRecording:(VCRRecording *)recording {
     if (recording.URI) {
         VCRRequestKey *key = [VCRRequestKey keyForObject:recording];
-        [self.responseDictionary setObject:recording forKey:key];
+        NSMutableArray * recordings = [self.responseDictionary objectForKey:key];
+
+        if (recordings == NULL) {
+            recordings = [[NSMutableArray alloc] init];
+            [self.responseDictionary setObject:recordings forKey:key];
+        }
+
+        [recordings addObject:recording];
     } else {
         [self.regexRecordings addObject:recording];
     }
 }
 
-- (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)key {
-    __block VCRRecording *recording = [self.responseDictionary objectForKey:key];
+- (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)key replaying:(BOOL)replaying {
+    __block VCRRecording *recording;
+    __block NSMutableArray *recordings = [self.responseDictionary objectForKey:key];
+
+    if (recordings != NULL && recordings.count > 0) {
+        recording = [recordings objectAtIndex:0];
+
+        if (recordings.count > 1 && replaying) {
+            [recordings removeObjectAtIndex:0];
+        }
+    }
 
     if (!recording) {
         [self.regexRecordings enumerateObjectsUsingBlock:^(VCRRecording *obj, NSUInteger idx, BOOL *stop) {
@@ -88,16 +104,27 @@
     return recording;
 }
 
-- (VCRRecording *)recordingForRequest:(NSURLRequest *)request {
+- (VCRRecording *)recordingForRequestKey:(VCRRequestKey *)key {
+    return [self recordingForRequestKey:key replaying:NO];
+}
+
+- (VCRRecording *)recordingForRequest:(NSURLRequest *)request replaying:(BOOL)replaying {
     VCRRequestKey *key = [VCRRequestKey keyForObject:request];
-    return [self recordingForRequestKey:key];
+    return [self recordingForRequestKey:key replaying:replaying];
+}
+
+- (VCRRecording *)recordingForRequest:(NSURLRequest *)request {
+    return [self recordingForRequest:request replaying:NO];
 }
 
 - (id)JSON {
     NSMutableArray *recordings = [NSMutableArray array];
-    for (VCRRecording *recording in self.responseDictionary.allValues) {
-        [recordings addObject:[recording JSON]];
+    for (NSArray *requestRecordings in self.responseDictionary.allValues) {
+        for (VCRRecording *recording in requestRecordings) {
+            [recordings addObject:[recording JSON]];
+        }
     }
+    
     for (VCRRecording *recording in self.regexRecordings) {
         [recordings addObject:[recording JSON]];
     }

--- a/VCRURLConnection/VCRReplayingURLProtocol.m
+++ b/VCRURLConnection/VCRReplayingURLProtocol.m
@@ -30,20 +30,20 @@
 @implementation VCRReplayingURLProtocol
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request {
-    return [VCR isReplaying] && [self recordingForRequest:request] && ([request.URL.scheme isEqualToString:@"https"] || [request.URL.scheme isEqualToString:@"http"]);
+    return [VCR isReplaying] && [self recordingForRequest:request replaying:NO] && ([request.URL.scheme isEqualToString:@"https"] || [request.URL.scheme isEqualToString:@"http"]);
 }
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request {
     return request;
 }
 
-+ (VCRRecording *)recordingForRequest:(NSURLRequest *)request {
++ (VCRRecording *)recordingForRequest:(NSURLRequest *)request replaying:(BOOL)replaying {
     VCRCassette *cassette = [[VCRCassetteManager defaultManager] currentCassette];
-    return [cassette recordingForRequest:request];
+    return [cassette recordingForRequest:request replaying:replaying];
 }
 
 - (void)startLoading {
-    VCRRecording *recording = [[self class] recordingForRequest:self.request];
+    VCRRecording *recording = [[self class] recordingForRequest:self.request replaying:YES];
     NSError *error = recording.error;
     if (!error) {
         NSURL *url = [NSURL URLWithString:recording.URI];


### PR DESCRIPTION
## Summary
This PR addresses issue https://github.com/dstnbrkr/VCRURLConnection/issues/33.

* Recordings are now saved in an array for each url+method key.
* After a recording is replayed, it's removed from array. The last recording in the array is not removed, to maintain compatibility with current behavior.

If `VCR` is in both recording and replaying mode, the replayed recording is added back to the queue. This behavior doesn't make a difference when there is only one recording per url. But when there are multiple responses, this creates a "loop". For example, responses `A` and `B` are in the array, the replay sequence becomes `A`, `B`, `A`, `B` etc. If `VCR` is only in replay mode, then the replayed sequence is `A`, `B`, `B`, `B`...