### PR TITLE
Makes the content types that should be considered "text" configurable

### DIFF
--- a/VCRURLConnection/VCR.h
+++ b/VCRURLConnection/VCR.h
@@ -62,6 +62,12 @@
 @interface VCR : NSObject
 
 /**
+ Provide a list of content types that should be considered text (e.g., "application/json"), so that the response
+ bodies won't get base64-encoded when saving them to file. Defaults to ["application/x-www-form-urlencoded"].
+ */
+@property (class) NSArray<NSString *> *textContentTypes;
+
+/**
  Load all recorded HTTP interactions from cassette JSON file at `url`
  */
 + (void)loadCassetteWithContentsOfURL:(NSURL *)url;

--- a/VCRURLConnection/VCR.m
+++ b/VCRURLConnection/VCR.m
@@ -32,8 +32,21 @@
 static BOOL _VCRIsRecording;
 static BOOL _VCRIsReplaying;
 
-
 @implementation VCR
+
+static NSArray<NSString *> *_textContentTypes;
+
++ (NSArray<NSString *> *)textContentTypes {
+    return _textContentTypes;
+}
+
++ (void)setTextContentTypes:(NSArray<NSString *> *)textContentTypes {
+    _textContentTypes = textContentTypes;
+}
+
++ (void)initialize {
+    _textContentTypes = @[ @"application/x-www-form-urlencoded" ];
+}
 
 + (void)loadCassetteWithContentsOfURL:(NSURL *)url {
     [[VCRCassetteManager defaultManager] setCurrentCassetteURL:url];

--- a/VCRURLConnection/VCRRecording.m
+++ b/VCRURLConnection/VCRRecording.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "VCRRecording.h"
+#import "VCR.h"
 #import "VCROrderedMutableDictionary.h"
 #import "VCRError.h"
 #if TARGET_OS_IPHONE
@@ -83,7 +84,7 @@
 
 - (BOOL)isText {
     NSString *type = [[self HTTPURLResponse] MIMEType] ?: @"text/plain";
-    if ([@[ @"application/x-www-form-urlencoded" ] containsObject:type]) {
+    if ([VCR.textContentTypes containsObject:type]) {
         return YES;
     }
     CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, (__bridge CFStringRef)type, NULL);


### PR DESCRIPTION
With the current VCRURLConnection master, responses from jsonApi endpoints will be saved base64-encoded to the cassette json. This is a pain when writing tests against the content returned in such responses.

With this pull request, the list of content types that are considered text (and therefore won't get base64-encoded when saved to file) has been made configurable.

In our tests (Swift), we're setting it to
```
VCR.textContentTypes = ["application/json",  "application/vnd.api+json"]
```
which will result in human-readable JSON in the cassettes.