### PR TITLE
Feature/delay

### DIFF
--- a/VCRURLConnection/VCR.h
+++ b/VCRURLConnection/VCR.h
@@ -62,6 +62,11 @@
 @interface VCR : NSObject
 
 /**
+ Set a delay for network-responses. Can be used to simulate bad network connections. Default: 0 (no delay)
+ */
+@property (class, nonatomic, assign) NSTimeInterval responseDelay;
+
+/**
  Load all recorded HTTP interactions from cassette JSON file at `url`
  */
 + (void)loadCassetteWithContentsOfURL:(NSURL *)url;

--- a/VCRURLConnection/VCR.m
+++ b/VCRURLConnection/VCR.m
@@ -31,9 +31,18 @@
 
 static BOOL _VCRIsRecording;
 static BOOL _VCRIsReplaying;
+static NSTimeInterval _responseDelay = 0;
 
 
 @implementation VCR
+
++ (void)setResponseDelay:(NSTimeInterval)responseDelay {
+    _responseDelay = responseDelay;
+}
+
++ (NSTimeInterval)responseDelay {
+    return _responseDelay;
+}
 
 + (void)loadCassetteWithContentsOfURL:(NSURL *)url {
     [[VCRCassetteManager defaultManager] setCurrentCassetteURL:url];

--- a/VCRURLConnection/VCRReplayingURLProtocol.m
+++ b/VCRURLConnection/VCRReplayingURLProtocol.m
@@ -43,19 +43,29 @@
 }
 
 - (void)startLoading {
-    VCRRecording *recording = [[self class] recordingForRequest:self.request];
-    NSError *error = recording.error;
-    if (!error) {
-        NSURL *url = [NSURL URLWithString:recording.URI];
-        NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
-                                                                  statusCode:recording.statusCode
-                                                                 HTTPVersion:@"HTTP/1.1"
-                                                                headerFields:recording.headerFields];
-        [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
-        [self.client URLProtocol:self didLoadData:recording.data];
-        [self.client URLProtocolDidFinishLoading:self];
+    void (^callback)() = ^() {
+        VCRRecording *recording = [[self class] recordingForRequest:self.request];
+        NSError *error = recording.error;
+        if (!error) {
+            NSURL *url = [NSURL URLWithString:recording.URI];
+            NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
+                                                                      statusCode:recording.statusCode
+                                                                     HTTPVersion:@"HTTP/1.1"
+                                                                    headerFields:recording.headerFields];
+            [self.client URLProtocol:self didReceiveResponse:response cacheStoragePolicy:NSURLCacheStorageNotAllowed];
+            [self.client URLProtocol:self didLoadData:recording.data];
+            [self.client URLProtocolDidFinishLoading:self];
+        } else {
+            [self.client URLProtocol:self didFailWithError:error];
+        }
+    };
+    
+    if ([VCR responseDelay] == 0) {
+        callback();
     } else {
-        [self.client URLProtocol:self didFailWithError:error];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)([VCR responseDelay] * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            callback();
+        });
     }
 }
 


### PR DESCRIPTION
A handy little feature that we are using for a while. 
Thx to @b-ray for implementing it.

This lets you define an optional response delay, to simulate loading time on mocked responses. 

I'd love to see this in the actual released version of the pod at some point, to not have to keep my branch up-to-date all the time :)