### PR TITLE
Update reference to ‘CoreServices’

### DIFF
--- a/VCRURLConnection.xcodeproj/project.pbxproj
+++ b/VCRURLConnection.xcodeproj/project.pbxproj
@@ -57,7 +57,6 @@
 		B3F466361BDDD548004624A9 /* XCTestCase+SRTAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B386A6F61ADA1AB100ABF873 /* XCTestCase+SRTAdditions.m */; };
 		B3F466381BDDD550004624A9 /* cassette-1.json in Resources */ = {isa = PBXBuildFile; fileRef = B386A6E41ADA1AB100ABF873 /* cassette-1.json */; };
 		B3F466391BDDD550004624A9 /* test.png in Resources */ = {isa = PBXBuildFile; fileRef = B386A6E61ADA1AB100ABF873 /* test.png */; };
-		B3F4663A1BDDD56F004624A9 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B3D88C9A1BDDD1A50001357A /* MobileCoreServices.framework */; };
 		B3FA968C1BDDC2FF007870A4 /* VCR_NSURLConnectionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B386A6E81ADA1AB100ABF873 /* VCR_NSURLConnectionTests.m */; };
 		B3FA968D1BDDC30A007870A4 /* VCR_NSURLSessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B386A6E91ADA1AB100ABF873 /* VCR_NSURLSessionTests.m */; };
 		B3FA968E1BDDC30A007870A4 /* VCRCassetteManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B386A6EB1ADA1AB100ABF873 /* VCRCassetteManagerTests.m */; };
@@ -70,6 +69,7 @@
 		B3FA96951BDDC30A007870A4 /* XCTestCase+SRTAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = B386A6F61ADA1AB100ABF873 /* XCTestCase+SRTAdditions.m */; };
 		B3FA96971BDDC515007870A4 /* cassette-1.json in Resources */ = {isa = PBXBuildFile; fileRef = B386A6E41ADA1AB100ABF873 /* cassette-1.json */; };
 		B3FA96981BDDC515007870A4 /* test.png in Resources */ = {isa = PBXBuildFile; fileRef = B386A6E61ADA1AB100ABF873 /* test.png */; };
+		F9496C53268107A9005035D2 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9496C52268107A9005035D2 /* CoreServices.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -148,6 +148,7 @@
 		B3FCE5061863F2D3009C0E12 /* VCRError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VCRError.m; sourceTree = "<group>"; };
 		C393569917B5DA460025DC53 /* VCROrderedMutableDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VCROrderedMutableDictionary.h; sourceTree = "<group>"; };
 		C393569A17B5DA460025DC53 /* VCROrderedMutableDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VCROrderedMutableDictionary.m; sourceTree = "<group>"; };
+		F9496C52268107A9005035D2 /* CoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreServices.framework; path = System/Library/Frameworks/CoreServices.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,7 +177,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B3F4663A1BDDD56F004624A9 /* MobileCoreServices.framework in Frameworks */,
+				F9496C53268107A9005035D2 /* CoreServices.framework in Frameworks */,
 				B3F466271BDDD50F004624A9 /* libVCRURLConnection.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -284,6 +285,7 @@
 		B3B82866167E9A6500CCEC3C /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F9496C52268107A9005035D2 /* CoreServices.framework */,
 				B3D88C9A1BDDD1A50001357A /* MobileCoreServices.framework */,
 				B386A7091ADA1E0000ABF873 /* MobileCoreServices.framework */,
 			);
@@ -453,6 +455,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = B3B8284C167E990F00CCEC3C;


### PR DESCRIPTION
This suppresses a warning, shown in iOS projects importing `VCRURLConnection-iOS`, that reads -

“MobileCoreServices has been renamed. Use CoreServices instead.”

<img src="https://user-images.githubusercontent.com/337963/122806049-dc215a00-d297-11eb-9950-557f86559d4c.png" width=300 />

